### PR TITLE
change archive_file from data to resource

### DIFF
--- a/modules/notifications/lambda/main.tf
+++ b/modules/notifications/lambda/main.tf
@@ -61,7 +61,7 @@ resource "aws_iam_role_policy_attachment" "lambda_execution" {
   policy_arn = aws_iam_policy.lambda_execution.arn
 }
 
-data "archive_file" "lambda" {
+resource "archive_file" "lambda" {
   type        = "zip"
   source_file = var.source_file
   output_path = "${path.module}/lambda_function_payload.zip"
@@ -69,13 +69,13 @@ data "archive_file" "lambda" {
 
 resource "aws_lambda_function" "team_sns_handler" {
   architectures = ["arm64"]
-  filename      = data.archive_file.lambda.output_path
+  filename      = resource.archive_file.lambda.output_path
   function_name = var.function_name
   handler       = "lambda_function.lambda_handler"
   role          = aws_iam_role.lambda_execution.arn
   runtime       = "python3.13"
 
-  source_code_hash = data.archive_file.lambda.output_base64sha256
+  source_code_hash = resource.archive_file.lambda.output_base64sha256
 }
 
 resource "aws_lambda_permission" "allow_sns" {


### PR DESCRIPTION
Change `archive_file` from `data` to `resource`. 

With the `data` block, the zip file gets created during the plan stage, and since our pipeline runs the apply in a clean environment the zip file is not present and the pipeline fails. With the `resource` block the zip file is created during the apply stage

https://github.com/hashicorp/terraform-provider-archive/issues/218