### PR TITLE
update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Add all engineers form the Core Cloud DevOps team to be owners of this repo
 # @org/team-name
-* @UKHomeOffice/core-cloud-devops
+* @UKHomeOffice/core-cloud-andromeda


### PR DESCRIPTION
Make andromeda codeowners to spare the wider team from notifications