### PR TITLE
CCL-3367 - update approvers groups to be iterable

### DIFF
--- a/modules/dynamodb/team_policies/main.tf
+++ b/modules/dynamodb/team_policies/main.tf
@@ -183,7 +183,7 @@ locals {
       groupIds = {
         L = [
           for approvers_group in policy.approvers_groups :
-            { S = data.aws_identitystore_group.approvers_group[policy.group_name].group_id }
+            { S = data.aws_identitystore_group.approvers_group[approvers_group].group_id }
         ]
       },
       modifiedBy = {

--- a/modules/dynamodb/team_policies/main.tf
+++ b/modules/dynamodb/team_policies/main.tf
@@ -173,7 +173,8 @@ locals {
       },
       approvers = {
         L = [
-          { S = data.aws_identitystore_group.approvers_group[policy.group_name].display_name }
+          for approvers_group in policy.approvers_groups :
+            { S = data.aws_identitystore_group.approvers_group[approvers_group].display_name }
         ]
       },
       createdAt = {
@@ -181,7 +182,8 @@ locals {
       },
       groupIds = {
         L = [
-          { S = data.aws_identitystore_group.approvers_group[policy.group_name].group_id }
+          for approvers_group in policy.approvers_groups :
+            { S = data.aws_identitystore_group.approvers_group[policy.group_name].group_id }
         ]
       },
       modifiedBy = {

--- a/modules/dynamodb/team_policies/main.tf
+++ b/modules/dynamodb/team_policies/main.tf
@@ -57,7 +57,7 @@ locals {
 
 # Read all unique approvers groups
 locals {
-  unique_approvers_group_names = toset([for policy in var.approvers_policies : trimspace(policy.group_name)])
+  unique_approvers_group_names = toset(flatten([for policy in var.approvers_policies : policy.approvers_groups]))
 }
 
 data "aws_identitystore_group" "approvers_group" {


### PR DESCRIPTION
Update Approvers Policy to take a list of approvers groups, rather than one group